### PR TITLE
Add yarn caching

### DIFF
--- a/.github/workflows/test-all-commits.yml
+++ b/.github/workflows/test-all-commits.yml
@@ -39,16 +39,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
 
-
+      # Workaround: At the moment, only lock files in the project root are
+      # supported...
+      # https://github.com/actions/setup-node#caching-packages-dependencies
+      - run: cp src/frontend/yarn.lock .
 
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          # At the moment, only lock files in the project root are supported...
-          # https://github.com/actions/setup-node#caching-packages-dependencies
-          #
-          # cache: 'yarn'
+          cache: 'yarn'
+
+      # Workaround: undo
+      - run: rm yarn.lock
 
       - name: Run Node tests
         run: |


### PR DESCRIPTION
Use workaround to enable `yarn.lock` dependencies to be cached.